### PR TITLE
Added instruction to delete apt cache and --no-install-recommends to …

### DIFF
--- a/network-deployment/install/Dockerfile.prereq
+++ b/network-deployment/install/Dockerfile.prereq
@@ -18,7 +18,7 @@ FROM ubuntu:16.04
 
 MAINTAINER Kavitha Suresh Kumar <kavisuresh@in.ibm.com>
 
-RUN apt-get update && apt-get install -y unzip wget
+RUN apt-get update && apt-get install -y --no-install-recommends unzip wget && rm -rf /var/lib/apt/lists/*
 
 ARG user=was
 


### PR DESCRIPTION
…reduce image size.

This may not be required because we eventually export only what's under `/opt/IBM/WebSphere/AppServer` but it's good practice.
