### PR TITLE
start the app server after federating for the first time

### DIFF
--- a/network-deployment/appserver/updateHostAndFederateServer.sh
+++ b/network-deployment/appserver/updateHostAndFederateServer.sh
@@ -45,12 +45,16 @@ startNodeAndServer()
      #if nodeagent started successfully , start the server
      if [ $? = 0 ]
      then
-           echo "Starting server......................."
-           /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/bin/startServer.sh server1
+           startServer
      else
            echo " Nodeagent startup failed , exiting....... "
            exit 1
      fi
+}
+
+startServer() {
+     echo "Starting server......................."
+     /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/bin/startServer.sh server1
 }
 
 stopServerAndNode()
@@ -77,7 +81,7 @@ updateHostNameAndAddNode()
      # Update the hostname
      /opt/IBM/WebSphere/AppServer/bin/wsadmin.sh -lang jython -conntype NONE -f /work/updateHostName.py \
      ServerNode $host
-    
+
      # Add the node
      /opt/IBM/WebSphere/AppServer/bin/addNode.sh $DMGR_HOST $DMGR_PORT
 
@@ -103,13 +107,15 @@ then
       startNodeAndServer
 else
       updateHostNameAndAddNode
-        
-      # Rename the node name and start the node
+
+      # Rename the node name
       if [ $NODE_NAME != "ServerNode" ]
       then
            renameNode
-           startNodeAndServer
       fi
+
+      # start the server
+      startServer
 fi
 
 trap "stopServerAndNode" SIGTERM


### PR DESCRIPTION
I noticed that previously I would always have to go to the console and manually start the app server after running the app server container for the first time.  However, if I then do a `docker stop` followed by a `docker start` on the app server container, it would start the server for me (as evidenced by the green check mark in the admin console).

So this change just makes the behavior consistent.  When you start the docker container for an app server, whether it is the first time or a subsequent time, it always starts the server for you.