### PR TITLE
Add a script for applying WAS configuration

### DIFF
--- a/base/Dockerfile.profile
+++ b/base/Dockerfile.profile
@@ -23,11 +23,19 @@ ARG NODE_NAME=DefaultNode01
 ARG HOST_NAME=localhost
 ARG SERVER_NAME=server1
 ARG ADMIN_USER_NAME=wsadmin
+ARG USER=was
 
 ENV PROFILE_NAME=$PROFILE_NAME \
   SERVER_NAME=$SERVER_NAME \
   ADMIN_USER_NAME=$ADMIN_USER_NAME
 
 RUN /work/create_profile
+
+COPY applyConfig.sh /work
+COPY applyConfig.py /work
+
+USER root
+RUN chown $USER:$USER -R /work && chmod +x /work/applyConfig.sh
+USER $USER
 
 CMD ["/work/start_server"]

--- a/base/applyConfig.py
+++ b/base/applyConfig.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+AdminTask.applyConfigProperties('[-propertiesFileName /work/was-config.props -validate true]')
+AdminConfig.save()

--- a/base/applyConfig.sh
+++ b/base/applyConfig.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [ -f /work/was-config.props ]; then
+	/opt/IBM/WebSphere/AppServer/bin/wsadmin.sh -conntype None -f /work/applyConfig.py
+fi

--- a/developer/profile/Dockerfile
+++ b/developer/profile/Dockerfile
@@ -23,11 +23,18 @@ ARG NODE_NAME=DefaultNode01
 ARG HOST_NAME=localhost
 ARG SERVER_NAME=server1
 ARG ADMIN_USER_NAME=wsadmin
-
+ARG USER=was
 ENV PROFILE_NAME=$PROFILE_NAME \
   SERVER_NAME=$SERVER_NAME \
   ADMIN_USER_NAME=$ADMIN_USER_NAME
 
 RUN /work/create_profile
+
+COPY applyConfig.sh /work
+COPY applyConfig.py /work
+
+USER root
+RUN chown $USER:$USER -R /work && chmod +x /work/applyConfig.sh
+USER $USER
 
 CMD ["/work/start_server"]

--- a/developer/profile/applyConfig.py
+++ b/developer/profile/applyConfig.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+AdminTask.applyConfigProperties('[-propertiesFileName /work/was-config.props -validate true]')
+AdminConfig.save()

--- a/developer/profile/applyConfig.sh
+++ b/developer/profile/applyConfig.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [ -f /work/was-config.props ]; then
+	/opt/IBM/WebSphere/AppServer/bin/wsadmin.sh -conntype None -f /work/applyConfig.py
+fi


### PR DESCRIPTION
Adds a script that will apply configuration from /work/was-config.props if the file is present.

Example was-config.props:
```
ResourceType=JavaVirtualMachine
ImplementingResourceType=Server
ResourceId=Cell=!{cellName}:Node=!{nodeName}:Server=!{serverName}:JavaProcessDef=ID
AttributeInfo=jvmEntries
#

#
#Properties
#
initialHeapSize=2048
```

Example Dockerfile
```
FROM websphere-traditional:profile
COPY was-config.props /work
RUN /work/applyConfig.sh
```

