### PR TITLE
Add link to config props reference in KCtr

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This will result in a Docker image that has your application and configuration p
 
 ### Adding properties during build phase 
 
-Starting with `9.0.0.9` the `profile` Docker Hub images contain a script, `/work/applyConfig.sh`, which will apply the properties found inside the `/work/config/was-config.props` file.  This script will be run with the server in `stopped` mode.
+Starting with `9.0.0.9` the `profile` Docker Hub images contain a script, `/work/applyConfig.sh`, which will apply the [config properties](https://www.ibm.com/support/knowledgecenter/en/SSAW57_9.0.0/com.ibm.websphere.nd.multiplatform.doc/ae/rxml_7propbasedconfig.html) found inside the `/work/config/was-config.props` file.  This script will be run with the server in `stopped` mode.
 
 For example, if you had the following `/work/config/was-config.props`:
 


### PR DESCRIPTION
I wasn't familiar with this type of config props function in wsadmin / WCCM, and had to look it up.  

So I thought it might help to link to a [reference](https://www.ibm.com/support/knowledgecenter/en/SSAW57_9.0.0/com.ibm.websphere.nd.multiplatform.doc/ae/rxml_7propbasedconfig.html) or maybe to just elaborate on what these properties are for someone less familiar.

Had a thought too to mention the [extract command](https://www.ibm.com/support/knowledgecenter/SSAW57_9.0.0/com.ibm.websphere.nd.multiplatform.doc/ae/txml_7extractprops.html) but I did see the warning in the [main article](https://www.ibm.com/support/knowledgecenter/en/SSAW57_9.0.0/com.ibm.websphere.nd.multiplatform.doc/ae/rxml_7propbasedconfig.html).

_Use properties files to customize, not replicate or merge environments. Do not extract an entire Cell, Node, Server, or ServerCluster to apply to a different environment. Only a subset of WCCM types are applied, and the extracted information is not merged with the new environment in a meaningful way._

Anyway, I still think given the huge topic that wsadmin is, some narrowing down of what this is doing might help..and this PR is just one idea of how to reference.