### PR TITLE
Enable HPEL before server starts

### DIFF
--- a/docker-build/9.0.0.x/scripts/configHPEL.py
+++ b/docker-build/9.0.0.x/scripts/configHPEL.py
@@ -1,7 +1,5 @@
 import os
 
-print os.environ
-
 cellName = os.environ.get('WAS_CELL')
 if cellName is None:
 	cellName = "DefaultCell01"

--- a/docker-build/9.0.0.x/scripts/configHPEL.py
+++ b/docker-build/9.0.0.x/scripts/configHPEL.py
@@ -1,0 +1,7 @@
+HPELService = AdminConfig.getid("/Cell:DefaultCell01/Node:DefaultNode01/Server:server1/HighPerformanceExtensibleLogging:/")
+AdminConfig.modify(HPELService, "[[enable true]]")
+
+RASLogging = AdminConfig.getid("/Cell:DefaultCell01/Node:DefaultNode01/Server:server1/RASLoggingService:/")
+AdminConfig.modify(RASLogging, "[[enable false]]")
+
+AdminConfig.save()

--- a/docker-build/9.0.0.x/scripts/configHPEL.py
+++ b/docker-build/9.0.0.x/scripts/configHPEL.py
@@ -1,7 +1,23 @@
-HPELService = AdminConfig.getid("/Cell:DefaultCell01/Node:DefaultNode01/Server:server1/HighPerformanceExtensibleLogging:/")
+import os
+
+print os.environ
+
+cellName = os.environ.get('WAS_CELL')
+if cellName is None:
+	cellName = "DefaultCell01"
+	
+nodeName = os.environ.get('NODE_NAME')
+if nodeName is None:
+	nodeName = "DefaultNode01"
+	
+serverName = os.environ.get('SERVER_NAME')
+if serverName is None:
+	serverName = "server1"
+
+HPELService = AdminConfig.getid("/Cell:%s/Node:%s/Server:%s/HighPerformanceExtensibleLogging:/"%(cellName,nodeName,serverName))
 AdminConfig.modify(HPELService, "[[enable true]]")
 
-RASLogging = AdminConfig.getid("/Cell:DefaultCell01/Node:DefaultNode01/Server:server1/RASLoggingService:/")
+RASLogging = AdminConfig.getid("/Cell:%s/Node:%s/Server:%s/RASLoggingService:/"%(cellName,nodeName,serverName))
 AdminConfig.modify(RASLogging, "[[enable false]]")
 
 AdminConfig.save()

--- a/docker-build/9.0.0.x/scripts/configure.sh
+++ b/docker-build/9.0.0.x/scripts/configure.sh
@@ -21,6 +21,5 @@ elif [ ! -z "$(ls /work/config)" ]; then
     echo "+ Found config-files under /work/config. Executing..."
     find /work/config -name "*.py" -exec /work/run_py_script.sh {} \;
 fi
-/work/configure_logging.sh
 work/applyConfig.sh
 stop_server

--- a/docker-build/9.0.0.x/scripts/configure.sh
+++ b/docker-build/9.0.0.x/scripts/configure.sh
@@ -21,5 +21,6 @@ elif [ ! -z "$(ls /work/config)" ]; then
     echo "+ Found config-files under /work/config. Executing..."
     find /work/config -name "*.py" -exec /work/run_py_script.sh {} \;
 fi
+/work/configure_logging.sh
 work/applyConfig.sh
 stop_server

--- a/docker-build/9.0.0.x/scripts/configure_logging.sh
+++ b/docker-build/9.0.0.x/scripts/configure_logging.sh
@@ -1,0 +1,5 @@
+ENABLE_BASIC_LOGGING="${ENABLE_BASIC_LOGGING:-false}"
+
+if [ "$ENABLE_BASIC_LOGGING" = false ]; then
+	/work/run_py_script.sh "/work/configHPEL.py"
+fi

--- a/docker-build/9.0.0.x/scripts/configure_logging.sh
+++ b/docker-build/9.0.0.x/scripts/configure_logging.sh
@@ -1,5 +1,5 @@
 ENABLE_BASIC_LOGGING="${ENABLE_BASIC_LOGGING:-false}"
 
 if [ "$ENABLE_BASIC_LOGGING" = false ]; then
-	/work/run_py_script.sh "/work/configHPEL.py"
+	/opt/IBM/WebSphere/AppServer/bin/wsadmin.sh -conntype None -f /work/configHPEL.py
 fi

--- a/docker-build/9.0.0.x/scripts/start_server.sh
+++ b/docker-build/9.0.0.x/scripts/start_server.sh
@@ -49,12 +49,7 @@ echo "ENABLE_BASIC_LOGGING is $ENABLE_BASIC_LOGGING"
 ENABLE_BASIC_LOGGING=${ENABLE_BASIC_LOGGING:-"false"}
 
 if [ "$ENABLE_BASIC_LOGGING" = false ]; then
-  echo "Setting Password"
-  /work/set_password.sh
-  start_server || exit $? > /dev/null
-  PID=$(ps -C java -o pid= | tr -d " ")
   configure_logging
-  stop_server
 fi
 
 applyConfigs

--- a/docker-build/9.0.0.x/scripts/start_server.sh
+++ b/docker-build/9.0.0.x/scripts/start_server.sh
@@ -40,6 +40,23 @@ applyConfigs(){
   fi
 }
 
+configure_logging(){
+  echo "Configure logging mode"
+  /work/configure_logging.sh
+}
+
+echo "ENABLE_BASIC_LOGGING is $ENABLE_BASIC_LOGGING"
+ENABLE_BASIC_LOGGING=${ENABLE_BASIC_LOGGING:-"false"}
+
+if [ "$ENABLE_BASIC_LOGGING" = false ]; then
+  echo "Setting Password"
+  /work/set_password.sh
+  start_server || exit $? > /dev/null
+  PID=$(ps -C java -o pid= | tr -d " ")
+  configure_logging
+  stop_server
+fi
+
 applyConfigs
 
 if [ ! -z "$EXTRACT_PORT_FROM_HOST_HEADER" ]; then
@@ -55,22 +72,36 @@ if [ "$UPDATE_HOSTNAME" = "true" ] && [ ! -f "/work/hostnameupdated" ]; then
 fi
 
 trap "stop_server" TERM INT
+
 start_server || exit $?
-
 PID=$(ps -C java -o pid= | tr -d " ")
-echo "$LOGGING_MODE"
-LOGGING_MODE=${LOGGING_MODE:-"HPEL"}
 
-if [ -e "/opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/logdata" ]; then
+if [ "$ENABLE_BASIC_LOGGING" = true ]; then
+  echo "Basic Logging is enabled"
+  tail -F /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemOut.log --pid $PID -n +0 &
+  tail -F /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemErr.log --pid $PID -n +0 >&2 &
+else
   echo "HPEL is enabled"
   rm -f /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemOut.log*
   rm -f /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemErr.log*
   run_logviewer
-else
-  tail -F /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemOut.log --pid $PID -n +0 &
-  tail -F /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemErr.log --pid $PID -n +0 >&2 &
 fi
 
 while [ -e "/proc/$PID" ]; do
+  ps cax | grep logViewer > /dev/null
+  if [ $? -eq 0 ]; then
+    echo "logViewer is running." > /dev/null
+  else
+    echo "logViewer is not running.  Restarting"
+    /opt/IBM/WebSphere/AppServer/bin/logViewer.sh -monitor -resumable -resume -format json | grep "^{" &
+  fi
   sleep 1
 done
+
+echo "WAS server1 is not running.  Stopping logViewer"
+
+PID=`ps cax | grep logViewer`
+if [ $? -eq 0 ]; then
+  kill -3 $PID
+  exit 0
+fi

--- a/docker-build/9.0.0.x/scripts/start_server.sh
+++ b/docker-build/9.0.0.x/scripts/start_server.sh
@@ -92,8 +92,10 @@ while [ -e "/proc/$PID" ]; do
   if [ $? -eq 0 ]; then
     echo "logViewer is running." > /dev/null
   else
-    echo "logViewer is not running.  Restarting"
-    /opt/IBM/WebSphere/AppServer/bin/logViewer.sh -monitor -resumable -resume -format json | grep "^{" &
+    if [ "$ENABLE_BASIC_LOGGING" = false ]; then
+      echo "logViewer is not running.  Restarting" > /dev/null
+      /opt/IBM/WebSphere/AppServer/bin/logViewer.sh -monitor -resumable -resume -format json | grep "^{" &
+    fi
   fi
   sleep 1
 done

--- a/docker-build/9.0.0.x/scripts/start_server.sh
+++ b/docker-build/9.0.0.x/scripts/start_server.sh
@@ -56,15 +56,20 @@ fi
 
 trap "stop_server" TERM INT
 start_server || exit $?
-run_logviewer
+
+PID=$(ps -C java -o pid= | tr -d " ")
+echo "$LOGGING_MODE"
+LOGGING_MODE=${LOGGING_MODE:-"HPEL"}
 
 if [ -e "/opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/logdata" ]; then
   echo "HPEL is enabled"
   rm -f /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemOut.log*
   rm -f /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemErr.log*
+  run_logviewer
+else
+  tail -F /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemOut.log --pid $PID -n +0 &
+  tail -F /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME/SystemErr.log --pid $PID -n +0 >&2 &
 fi
-
-PID=$(ps -C java -o pid= | tr -d " ")
 
 while [ -e "/proc/$PID" ]; do
   sleep 1


### PR DESCRIPTION
1. adding configHPEL.py to configure the server to use HPEL before server starts
2. When start_server.sh is executed, run logViewer command to display logs in js
on format in standard out
3. Removing SystemOut.log and SystemErr.log and owner files as they will not be used