### PR TITLE
Fix EXTRACT_PORT_FROM_HOST_HEADER variable check

### DIFF
--- a/docker-build/9.0.0.10/scripts/start_server.sh
+++ b/docker-build/9.0.0.10/scripts/start_server.sh
@@ -56,7 +56,7 @@ fi
 
 applyConfigs
 
-if [ ! -z "$EXTRACT_PORT_FROM_HOST_HEADER" ]; then
+if [ "$EXTRACT_PORT_FROM_HOST_HEADER" = "true" ]; then
   /work/applyConfig.sh /work/config-ibm/webContainer.props
 fi
 

--- a/docker-build/9.0.0.9/scripts/start_server.sh
+++ b/docker-build/9.0.0.9/scripts/start_server.sh
@@ -37,7 +37,7 @@ applyConfigs(){
 
 applyConfigs
 
-if [ ! -z "$EXTRACT_PORT_FROM_HOST_HEADER" ]; then
+if [ "$EXTRACT_PORT_FROM_HOST_HEADER" = "true" ]; then
   /work/applyConfig.sh /work/config-ibm/webContainer.props
 fi
 

--- a/docker-build/9.0.0.x/scripts/start_server.sh
+++ b/docker-build/9.0.0.x/scripts/start_server.sh
@@ -56,7 +56,7 @@ fi
 
 applyConfigs
 
-if [ ! -z "$EXTRACT_PORT_FROM_HOST_HEADER" ]; then
+if [ "$EXTRACT_PORT_FROM_HOST_HEADER" = "true" ]; then
   /work/applyConfig.sh /work/config-ibm/webContainer.props
 fi
 


### PR DESCRIPTION
Currently setting the EXTRACT_PORT_FROM_HOST_HEADER to false still adds webcontainer properties. 