### PR TITLE
Improve running with random UID

### DIFF
--- a/docker-build/9.0.0.10/Dockerfile
+++ b/docker-build/9.0.0.10/Dockerfile
@@ -92,7 +92,8 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:$PATH \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \
-  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w
+  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w \
+  && chmod -R g+rwx /home/was/.java/
 
 USER root
 RUN ln -s /opt/IBM/WebSphere/AppServer/profiles/${PROFILE_NAME}/logs /logs && chown 1001:0 /logs

--- a/docker-build/9.0.0.10/Dockerfile.offline
+++ b/docker-build/9.0.0.10/Dockerfile.offline
@@ -45,7 +45,8 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:$PATH \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \
-  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w
+  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w \
+  && chmod -R g+rwx /home/was/.java/
 
 USER root
 RUN ln -s /opt/IBM/WebSphere/AppServer/profiles/${PROFILE_NAME}/logs /logs && chown 1001:0 /logs

--- a/docker-build/9.0.0.10/scripts/config-ibm/jvmUserRoot.props
+++ b/docker-build/9.0.0.10/scripts/config-ibm/jvmUserRoot.props
@@ -1,0 +1,7 @@
+
+ResourceType=JavaVirtualMachine
+ImplementingResourceType=Server
+ResourceId=Cell=!{cellName}:Node=!{nodeName}:Server=!{serverName}:JavaProcessDef=:JavaVirtualMachine=
+AttributeInfo=systemProperties(name,value)
+#Properties
+java.util.prefs.userRoot=/home/was/

--- a/docker-build/9.0.0.10/scripts/configure.sh
+++ b/docker-build/9.0.0.10/scripts/configure.sh
@@ -23,3 +23,5 @@ elif [ ! -z "$(ls /work/config)" ]; then
 fi
 work/applyConfig.sh
 stop_server
+find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 -r chmod g+w
+find /opt/IBM -type d -user was ! -perm -g=x -print0 | xargs -0 -r chmod g+x

--- a/docker-build/9.0.0.10/scripts/create_profile.sh
+++ b/docker-build/9.0.0.10/scripts/create_profile.sh
@@ -21,4 +21,5 @@ if [ ! -d /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME 
     -templatePath /opt/IBM/WebSphere/AppServer/profileTemplates/default \
     -nodeName $NODE_NAME -cellName $CELL_NAME -hostName $HOST_NAME \
     -serverName $SERVER_NAME -enableAdminSecurity true -adminUserName $ADMIN_USER_NAME -adminPassword "CHANGEME" -omitAction defaultAppDeployAndConfig deployIVTApplication
+  /work/applyConfig.sh /work/config-ibm/jvmUserRoot.props
 fi

--- a/docker-build/9.0.0.11/Dockerfile
+++ b/docker-build/9.0.0.11/Dockerfile
@@ -92,7 +92,8 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:$PATH \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \
-  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w
+  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w \
+  && chmod -R g+rwx /home/was/.java/
 
 USER root
 RUN ln -s /opt/IBM/WebSphere/AppServer/profiles/${PROFILE_NAME}/logs /logs && chown 1001:0 /logs

--- a/docker-build/9.0.0.11/Dockerfile.offline
+++ b/docker-build/9.0.0.11/Dockerfile.offline
@@ -45,7 +45,8 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:$PATH \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \
-  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w
+  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w \
+  && chmod -R g+rwx /home/was/.java/
 
 USER root
 RUN ln -s /opt/IBM/WebSphere/AppServer/profiles/${PROFILE_NAME}/logs /logs && chown 1001:0 /logs

--- a/docker-build/9.0.0.11/scripts/config-ibm/jvmUserRoot.props
+++ b/docker-build/9.0.0.11/scripts/config-ibm/jvmUserRoot.props
@@ -1,0 +1,7 @@
+
+ResourceType=JavaVirtualMachine
+ImplementingResourceType=Server
+ResourceId=Cell=!{cellName}:Node=!{nodeName}:Server=!{serverName}:JavaProcessDef=:JavaVirtualMachine=
+AttributeInfo=systemProperties(name,value)
+#Properties
+java.util.prefs.userRoot=/home/was/

--- a/docker-build/9.0.0.11/scripts/configure.sh
+++ b/docker-build/9.0.0.11/scripts/configure.sh
@@ -23,3 +23,5 @@ elif [ ! -z "$(ls /work/config)" ]; then
 fi
 work/applyConfig.sh
 stop_server
+find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 -r chmod g+w
+find /opt/IBM -type d -user was ! -perm -g=x -print0 | xargs -0 -r chmod g+x

--- a/docker-build/9.0.0.11/scripts/create_profile.sh
+++ b/docker-build/9.0.0.11/scripts/create_profile.sh
@@ -21,4 +21,5 @@ if [ ! -d /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME 
     -templatePath /opt/IBM/WebSphere/AppServer/profileTemplates/default \
     -nodeName $NODE_NAME -cellName $CELL_NAME -hostName $HOST_NAME \
     -serverName $SERVER_NAME -enableAdminSecurity true -adminUserName $ADMIN_USER_NAME -adminPassword "CHANGEME" -omitAction defaultAppDeployAndConfig deployIVTApplication
+  /work/applyConfig.sh /work/config-ibm/jvmUserRoot.props
 fi

--- a/docker-build/9.0.0.9/Dockerfile
+++ b/docker-build/9.0.0.9/Dockerfile
@@ -92,7 +92,8 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:$PATH \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \
-  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w
+  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w \
+  && chmod -R g+rwx /home/was/.java/
 
 USER root
 RUN ln -s /opt/IBM/WebSphere/AppServer/profiles/${PROFILE_NAME}/logs /logs && chown 1001:0 /logs

--- a/docker-build/9.0.0.9/scripts/config-ibm/jvmUserRoot.props
+++ b/docker-build/9.0.0.9/scripts/config-ibm/jvmUserRoot.props
@@ -1,0 +1,7 @@
+
+ResourceType=JavaVirtualMachine
+ImplementingResourceType=Server
+ResourceId=Cell=!{cellName}:Node=!{nodeName}:Server=!{serverName}:JavaProcessDef=:JavaVirtualMachine=
+AttributeInfo=systemProperties(name,value)
+#Properties
+java.util.prefs.userRoot=/home/was/

--- a/docker-build/9.0.0.9/scripts/configure.sh
+++ b/docker-build/9.0.0.9/scripts/configure.sh
@@ -23,3 +23,5 @@ elif [ ! -z "$(ls /work/config)" ]; then
 fi
 work/applyConfig.sh
 stop_server
+find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 -r chmod g+w
+find /opt/IBM -type d -user was ! -perm -g=x -print0 | xargs -0 -r chmod g+x

--- a/docker-build/9.0.0.9/scripts/create_profile.sh
+++ b/docker-build/9.0.0.9/scripts/create_profile.sh
@@ -21,4 +21,5 @@ if [ ! -d /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME 
     -templatePath /opt/IBM/WebSphere/AppServer/profileTemplates/default \
     -nodeName $NODE_NAME -cellName $CELL_NAME -hostName $HOST_NAME \
     -serverName $SERVER_NAME -enableAdminSecurity true -adminUserName $ADMIN_USER_NAME -adminPassword "CHANGEME" -omitAction defaultAppDeployAndConfig deployIVTApplication
+  /work/applyConfig.sh /work/config-ibm/jvmUserRoot.props
 fi

--- a/docker-build/9.0.5.x/Dockerfile
+++ b/docker-build/9.0.5.x/Dockerfile
@@ -92,7 +92,8 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:$PATH \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \
-  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w
+  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w \
+  && chmod -R g+rwx /home/was/.java/
 
 USER root
 RUN ln -s /opt/IBM/WebSphere/AppServer/profiles/${PROFILE_NAME}/logs /logs && chown 1001:0 /logs

--- a/docker-build/9.0.5.x/Dockerfile.offline
+++ b/docker-build/9.0.5.x/Dockerfile.offline
@@ -45,7 +45,8 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:$PATH \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \
-  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w
+  && find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 chmod g+w \
+  && chmod -R g+rwx /home/was/.java/
 
 USER root
 RUN ln -s /opt/IBM/WebSphere/AppServer/profiles/${PROFILE_NAME}/logs /logs && chown 1001:0 /logs

--- a/docker-build/9.0.5.x/scripts/config-ibm/jvmUserRoot.props
+++ b/docker-build/9.0.5.x/scripts/config-ibm/jvmUserRoot.props
@@ -1,0 +1,7 @@
+
+ResourceType=JavaVirtualMachine
+ImplementingResourceType=Server
+ResourceId=Cell=!{cellName}:Node=!{nodeName}:Server=!{serverName}:JavaProcessDef=:JavaVirtualMachine=
+AttributeInfo=systemProperties(name,value)
+#Properties
+java.util.prefs.userRoot=/home/was/

--- a/docker-build/9.0.5.x/scripts/configure.sh
+++ b/docker-build/9.0.5.x/scripts/configure.sh
@@ -23,3 +23,5 @@ elif [ ! -z "$(ls /work/config)" ]; then
 fi
 work/applyConfig.sh
 stop_server
+find /opt/IBM -user was ! -perm -g=w -print0 | xargs -0 -r chmod g+w
+find /opt/IBM -type d -user was ! -perm -g=x -print0 | xargs -0 -r chmod g+x

--- a/docker-build/9.0.5.x/scripts/create_profile.sh
+++ b/docker-build/9.0.5.x/scripts/create_profile.sh
@@ -21,4 +21,5 @@ if [ ! -d /opt/IBM/WebSphere/AppServer/profiles/$PROFILE_NAME/logs/$SERVER_NAME 
     -templatePath /opt/IBM/WebSphere/AppServer/profileTemplates/default \
     -nodeName $NODE_NAME -cellName $CELL_NAME -hostName $HOST_NAME \
     -serverName $SERVER_NAME -enableAdminSecurity true -adminUserName $ADMIN_USER_NAME -adminPassword "CHANGEME" -omitAction defaultAppDeployAndConfig deployIVTApplication
+  /work/applyConfig.sh /work/config-ibm/jvmUserRoot.props
 fi


### PR DESCRIPTION
1. Set  java.util.prefs.user.root system property to always point to /home/was
2. Make sure that newly generated files during configure.sh have correct group permissions 
