### PR TITLE
Fix BuildLabel for tWAS images

### DIFF
--- a/docker-build/9.0.0.10/Dockerfile
+++ b/docker-build/9.0.0.10/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y openssl wget unzip
 ARG IMURL
 ARG IBMID
 ARG IBMID_PWD
-ARG BUILDLABEL=cf101846.03
 ARG IFIXES=none
 ARG PRODUCTID=com.ibm.websphere.ILAN.v90_9.0.10.20181119_1807
 ARG REPO=https://www.ibm.com/software/repositorymanager/V9WASILAN
@@ -56,6 +55,7 @@ RUN sed -i 's/-Xms256m/-Xms1024m/g' /opt/IBM/WebSphere/AppServer/bin/wsadmin.sh 
 
 # Final image
 FROM ubuntu:16.04
+ARG BUILDLABEL=cf101846.03
 
 LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com>" \
       BuildLabel="$BUILDLABEL"

--- a/docker-build/9.0.0.11/Dockerfile
+++ b/docker-build/9.0.0.11/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y openssl wget unzip
 ARG IMURL
 ARG IBMID
 ARG IBMID_PWD
-ARG BUILDLABEL=cf111849.01
 ARG IFIXES=none
 ARG PRODUCTID=com.ibm.websphere.ILAN.v90_9.0.11.20190312_2048
 ARG REPO=https://www.ibm.com/software/repositorymanager/V9WASILAN
@@ -56,6 +55,7 @@ RUN sed -i 's/-Xms256m/-Xms1024m/g' /opt/IBM/WebSphere/AppServer/bin/wsadmin.sh 
 
 # Final image
 FROM ubuntu:16.04
+ARG BUILDLABEL=cf111849.01
 
 LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com>" \
       BuildLabel="$BUILDLABEL"

--- a/docker-build/9.0.0.9/Dockerfile
+++ b/docker-build/9.0.0.9/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y openssl wget unzip
 ARG IMURL
 ARG IBMID
 ARG IBMID_PWD
-ARG BUILDLABEL=cf091835.02
 ARG IFIXES=none
 ARG PRODUCTID=com.ibm.websphere.ILAN.v90_9.0.9.20180906_1004
 ARG REPO=https://www.ibm.com/software/repositorymanager/V9WASILAN
@@ -56,6 +55,7 @@ RUN sed -i 's/-Xms256m/-Xms1024m/g' /opt/IBM/WebSphere/AppServer/bin/wsadmin.sh 
 
 # Final image
 FROM ubuntu:16.04
+ARG BUILDLABEL=cf091835.02
 
 LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com>" \
       BuildLabel="$BUILDLABEL"

--- a/docker-build/9.0.5.x/Dockerfile
+++ b/docker-build/9.0.5.x/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y openssl wget unzip
 ARG IMURL
 ARG IBMID
 ARG IBMID_PWD
-ARG BUILDLABEL=none
 ARG IFIXES=none
 ARG PRODUCTID=com.ibm.websphere.ILAN.v90
 ARG REPO=https://www.ibm.com/software/repositorymanager/V9WASILAN
@@ -56,6 +55,7 @@ RUN sed -i 's/-Xms256m/-Xms1024m/g' /opt/IBM/WebSphere/AppServer/bin/wsadmin.sh 
 
 # Final image
 FROM ubuntu:16.04
+ARG BUILDLABEL=none
 
 LABEL maintainer="Arthur De Magalhaes <arthurdm@ca.ibm.com>" \
       BuildLabel="$BUILDLABEL"


### PR DESCRIPTION
Fixing an issue where the BuildLabel was blank when inspecting the tWAS docker images.