### PR TITLE
update pipeline for openshift

### DIFF
--- a/samples/hello-world/openshift/README.md
+++ b/samples/hello-world/openshift/README.md
@@ -6,7 +6,7 @@ mkdir demo
 cd demo
 
 ### Clone this repo
-git clone git@github.com:WASdev/ci.docker.websphere-traditional.git
+git clone https://github.com/WASdev/ci.docker.websphere-traditional.git
 
 cd ci.docker.websphere-traditional
 

--- a/samples/hello-world/openshift/subscription.yaml
+++ b/samples/hello-world/openshift/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-pipelines-operator-rh
   namespace: openshift-operators
 spec:
-  channel: ocp-4.6
+  channel: stable
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
use http instead of git to clone repo and replace ocp-4.6 stream in subscription with stable