### PR TITLE
Add Docker secrets support for wsadmin password config

### DIFF
--- a/docker-build/9.0.5.x/Dockerfile-ubi8
+++ b/docker-build/9.0.5.x/Dockerfile-ubi8
@@ -94,6 +94,7 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:${PATH} \
     PROFILE_NAME=$PROFILE_NAME \
     SERVER_NAME=$SERVER_NAME \
     ADMIN_USER_NAME=$ADMIN_USER_NAME \
+    SECRET_NAME=$SECRET_NAME \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \

--- a/docker-build/9.0.5.x/Dockerfile.ipla
+++ b/docker-build/9.0.5.x/Dockerfile.ipla
@@ -94,6 +94,7 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:${PATH} \
     PROFILE_NAME=$PROFILE_NAME \
     SERVER_NAME=$SERVER_NAME \
     ADMIN_USER_NAME=$ADMIN_USER_NAME \
+    SECRET_NAME=$SECRET_NAME \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \

--- a/docker-build/9.0.5.x/Dockerfile.ipla-rec
+++ b/docker-build/9.0.5.x/Dockerfile.ipla-rec
@@ -94,6 +94,7 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:${PATH} \
     PROFILE_NAME=$PROFILE_NAME \
     SERVER_NAME=$SERVER_NAME \
     ADMIN_USER_NAME=$ADMIN_USER_NAME \
+    SECRET_NAME=$SECRET_NAME \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \

--- a/docker-build/9.0.5.x/Dockerfile.offline
+++ b/docker-build/9.0.5.x/Dockerfile.offline
@@ -63,6 +63,7 @@ ENV PATH=/opt/IBM/WebSphere/AppServer/bin:${PATH} \
     PROFILE_NAME=$PROFILE_NAME \
     SERVER_NAME=$SERVER_NAME \
     ADMIN_USER_NAME=$ADMIN_USER_NAME \
+    SECRET_NAME=$SECRET_NAME \
     EXTRACT_PORT_FROM_HOST_HEADER=true
 
 RUN /work/create_profile.sh \

--- a/docker-build/9.0.5.x/scripts/set_password.sh
+++ b/docker-build/9.0.5.x/scripts/set_password.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 #####################################################################################
 #                                                                                   #
-#  Script to set the wsadmin password.                                              #
-#  If a value exists in /tmp/PASSWORD that value will be used,                      #
-#  otherwise a random value will be generated and used (and also                    #
-#  persisted in /tmp/PASSWORD).                                                     #
+#  Script to set the wsadmin password. There are three ways to obtain the value:    #
+#   - Docker secret (preferred).                                                    #
+#   - Content of /tmp/PASSWORD (defined in the previous runtime).                   #
+#   - Random value (fallback).                                                      #
 #                                                                                   #
 #  Usage : set_password                                                             #
 #                                                                                   #
 #####################################################################################
 
 ADMIN_USER_NAME=${ADMIN_USER_NAME:-"wsadmin"}
+SECRET_ROOT='/run/secrets'
+SECRET_NAME=${SECRET_NAME:-"wsadmin_password"}
+WAS_PASSWD_FILE='/tmp/PASSWORD'
+WAS_UPD_PASSWD_FILE='/tmp/passwordupdated'
 
-if [ -f /tmp/PASSWORD ]
-then
-  password=$(cat /tmp/PASSWORD)
+if [ -f ${SECRET_ROOT}/${SECRET_NAME} ]; then
+  password="$(cat ${SECRET_ROOT}/${SECRET_NAME})"
+
+elif [ -f $WAS_PASSWD_FILE ]; then
+  password="$(cat $WAS_PASSWD_FILE)"
+
 else
-  password=$(openssl rand -base64 6)
-  echo $password > /tmp/PASSWORD
+  password="$(openssl rand -base64 6)"
+  echo "$password" > $WAS_PASSWD_FILE
 fi
 
-/opt/IBM/WebSphere/AppServer/bin/wsadmin.sh -lang jython -conntype NONE -f /work/updatePassword.py $ADMIN_USER_NAME $password > /dev/null 2>&1
-echo $password > /tmp/passwordupdated
+/opt/IBM/WebSphere/AppServer/bin/wsadmin.sh -lang jython -conntype NONE -f /work/updatePassword.py "$ADMIN_USER_NAME" "$password" > /dev/null 2>&1
+echo "$password" > $WAS_UPD_PASSWD_FILE


### PR DESCRIPTION
Hi.

This pull requests contains all the changes to set the wsadmin password from a Docker secret, even having the workaround by bind-mounting the `/tmp/PASSWORD` and `/tmp/passwordupdated` files from the host with the desired password.

To make this consistent, the environment variable `SECRET_NAME` has been created to customize the secret management without breaking anything in the service. The script defaults it to `wsadmin_password`.

If you have any questions or suggestion please feel free to comment here.

Greetings from Cartagena (Spain).