### PR TITLE
Always produce OCI-format images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     # You are encouraged to use static refs such as tags, instead of branch name
     #
     # Running "pre-commit autoupdate" automatically updates rev to latest tag
-    rev: 0.13.1+ibm.61.dss
+    rev: 0.13.1+ibm.64.dss
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-12-23T17:41:31Z",
+  "generated_at": "2026-09-09T15:01:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -98,7 +98,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/docker-build/build_all.sh
+++ b/docker-build/build_all.sh
@@ -130,7 +130,7 @@ for current_dir in *; do
         fi
         echo "Disk Space (Used  Total)=$(df -h --output=used,size . | tail -n 1) -prebuild ${IMAGE}"
         echo "---------- START Building websphere-traditional:${IMAGE} ----------"
-        buildCommand="${CONTAINER_CMD} build -t websphere-traditional:${IMAGE} -f ${DOCKERFILE} ${current_dir} --build-arg IBMID=\"${username}\" --build-arg IBMID_PWD=\"${password}\""
+        buildCommand="${CONTAINER_CMD} build --format oci -t websphere-traditional:${IMAGE} -f ${DOCKERFILE} ${current_dir} --build-arg IBMID=\"${username}\" --build-arg IBMID_PWD=\"${password}\""
         if [ ! -z "${repo}" ]
         then 
           buildCommand="${buildCommand} --build-arg REPO=\"${repo}\""
@@ -160,7 +160,7 @@ for current_dir in *; do
           echo "Disk Space (Used  Total)=$(df -h --output=used,size . | tail -n 1) -prebuildsample ${IMAGE}"
           echo "---------- START Building websphere-traditional/sample-app:${IMAGE} ----------"
           ${CONTAINER_CMD} tag websphere-traditional:${IMAGE} icr.io/appcafe/websphere-traditional:latest
-          ${CONTAINER_CMD} build -t websphere-traditional/sample-app:${IMAGE} ../samples/hello-world
+          ${CONTAINER_CMD} build --format oci -t websphere-traditional/sample-app:${IMAGE} ../samples/hello-world
           rc=$?
           ${CONTAINER_CMD} rmi icr.io/appcafe/websphere-traditional:latest
           if [ $rc -ne 0 ]

--- a/docker-build/build_all.sh
+++ b/docker-build/build_all.sh
@@ -130,7 +130,12 @@ for current_dir in *; do
         fi
         echo "Disk Space (Used  Total)=$(df -h --output=used,size . | tail -n 1) -prebuild ${IMAGE}"
         echo "---------- START Building websphere-traditional:${IMAGE} ----------"
-        buildCommand="${CONTAINER_CMD} build --format oci -t websphere-traditional:${IMAGE} -f ${DOCKERFILE} ${current_dir} --build-arg IBMID=\"${username}\" --build-arg IBMID_PWD=\"${password}\""
+        if [ "${CONTAINER_CMD}" = "docker" ]; then
+          BUILD_CMD="docker buildx build --output=type=image,oci-mediatypes=true"
+        else
+          BUILD_CMD="${CONTAINER_CMD} build --format oci"
+        fi
+        buildCommand="${BUILD_CMD} -t websphere-traditional:${IMAGE} -f ${DOCKERFILE} ${current_dir} --build-arg IBMID=\"${username}\" --build-arg IBMID_PWD=\"${password}\""
         if [ ! -z "${repo}" ]
         then 
           buildCommand="${buildCommand} --build-arg REPO=\"${repo}\""
@@ -160,7 +165,12 @@ for current_dir in *; do
           echo "Disk Space (Used  Total)=$(df -h --output=used,size . | tail -n 1) -prebuildsample ${IMAGE}"
           echo "---------- START Building websphere-traditional/sample-app:${IMAGE} ----------"
           ${CONTAINER_CMD} tag websphere-traditional:${IMAGE} icr.io/appcafe/websphere-traditional:latest
-          ${CONTAINER_CMD} build --format oci -t websphere-traditional/sample-app:${IMAGE} ../samples/hello-world
+          if [ "${CONTAINER_CMD}" = "docker" ]; then
+            SAMPLE_BUILD_CMD="docker buildx build --output=type=image,oci-mediatypes=true"
+          else
+            SAMPLE_BUILD_CMD="${CONTAINER_CMD} build --format oci"
+          fi
+          ${SAMPLE_BUILD_CMD} -t websphere-traditional/sample-app:${IMAGE} ../samples/hello-world
           rc=$?
           ${CONTAINER_CMD} rmi icr.io/appcafe/websphere-traditional:latest
           if [ $rc -ne 0 ]

--- a/docker-build/build_all.sh
+++ b/docker-build/build_all.sh
@@ -133,7 +133,7 @@ for current_dir in *; do
         if [ "${CONTAINER_CMD}" = "docker" ]; then
           BUILD_CMD="docker buildx build --output=type=image,oci-mediatypes=true"
         else
-          BUILD_CMD="${CONTAINER_CMD} build --format oci"
+          BUILD_CMD="podman build --format oci"
         fi
         buildCommand="${BUILD_CMD} -t websphere-traditional:${IMAGE} -f ${DOCKERFILE} ${current_dir} --build-arg IBMID=\"${username}\" --build-arg IBMID_PWD=\"${password}\""
         if [ ! -z "${repo}" ]
@@ -168,7 +168,7 @@ for current_dir in *; do
           if [ "${CONTAINER_CMD}" = "docker" ]; then
             SAMPLE_BUILD_CMD="docker buildx build --output=type=image,oci-mediatypes=true"
           else
-            SAMPLE_BUILD_CMD="${CONTAINER_CMD} build --format oci"
+            SAMPLE_BUILD_CMD="podman build --format oci"
           fi
           ${SAMPLE_BUILD_CMD} -t websphere-traditional/sample-app:${IMAGE} ../samples/hello-world
           rc=$?

--- a/docker-build/build_installer.sh
+++ b/docker-build/build_installer.sh
@@ -122,6 +122,6 @@ for current_os in ubi8; do
       echo "Not building ${current_os} because ${DOCKERFILE} does not exist."
       continue
     fi
-    ${CONTAINER_CMD} build -t agent-installer:${current_os} -f ${DOCKERFILE} agent.installer --build-arg IMZIP=agent.installer.${arch}.zip
+    ${CONTAINER_CMD} build --format oci -t agent-installer:${current_os} -f ${DOCKERFILE} agent.installer --build-arg IMZIP=agent.installer.${arch}.zip
   fi
 done

--- a/docker-build/build_installer.sh
+++ b/docker-build/build_installer.sh
@@ -122,6 +122,11 @@ for current_os in ubi8; do
       echo "Not building ${current_os} because ${DOCKERFILE} does not exist."
       continue
     fi
-    ${CONTAINER_CMD} build --format oci -t agent-installer:${current_os} -f ${DOCKERFILE} agent.installer --build-arg IMZIP=agent.installer.${arch}.zip
+    if [ "${CONTAINER_CMD}" = "docker" ]; then
+      INSTALLER_BUILD_CMD="docker buildx build --output=type=image,oci-mediatypes=true"
+    else
+      INSTALLER_BUILD_CMD="${CONTAINER_CMD} build --format oci"
+    fi
+    ${INSTALLER_BUILD_CMD} -t agent-installer:${current_os} -f ${DOCKERFILE} agent.installer --build-arg IMZIP=agent.installer.${arch}.zip
   fi
 done

--- a/docker-build/build_installer.sh
+++ b/docker-build/build_installer.sh
@@ -125,7 +125,7 @@ for current_os in ubi8; do
     if [ "${CONTAINER_CMD}" = "docker" ]; then
       INSTALLER_BUILD_CMD="docker buildx build --output=type=image,oci-mediatypes=true"
     else
-      INSTALLER_BUILD_CMD="${CONTAINER_CMD} build --format oci"
+      INSTALLER_BUILD_CMD="podman build --format oci"
     fi
     ${INSTALLER_BUILD_CMD} -t agent-installer:${current_os} -f ${DOCKERFILE} agent.installer --build-arg IMZIP=agent.installer.${arch}.zip
   fi


### PR DESCRIPTION
- For Docker use `docker buildx build --output=type=image,oci-mediatypes=true` - Uses BuildKit with OCI media types explicitly enabled, which is the correct way to guarantee OCI output in Docker.
- For Podman use `build --format oci` Podman's native --format oci flag produces OCI v1.0 manifests (its documented default).